### PR TITLE
Update paper.bib

### DIFF
--- a/88presentación/jose_2024/paper.bib
+++ b/88presentación/jose_2024/paper.bib
@@ -1,5 +1,4 @@
-
-@article{mason_comparing_2013,
+@article{masonComparing:2013,
 	title = {Comparing the Effectiveness of an Inverted Classroom to a Traditional Classroom in an Upper-Division Engineering Course},
 	volume = {56},
 	issn = {0018-9359, 1557-9638},
@@ -17,7 +16,7 @@
 	file = {Mason et al. - 2013 - Comparing the Effectiveness of an Inverted Classro.pdf:/home/vbettachini/storage/Zotero/storage/JD5VKTX8/Mason et al. - 2013 - Comparing the Effectiveness of an Inverted Classro.pdf:application/pdf},
 }
 
-@article{vallejo_google_2022,
+@article{vallejoGoogle:2022,
 	title = {Google Colab and Virtual Simulations: Practical e-Learning Tools to Support the Teaching of Thermodynamics and to Introduce Coding to Students},
 	volume = {7},
 	issn = {2470-1343, 2470-1343},
@@ -36,7 +35,7 @@
 	file = {Vallejo et al. - 2022 - Google Colab and Virtual Simulations Practical e-.pdf:/home/vbettachini/storage/Zotero/storage/CDRGEZUY/Vallejo et al. - 2022 - Google Colab and Virtual Simulations Practical e-.pdf:application/pdf},
 }
 
-@article{cumby_course_2023,
+@article{cumbyCourse:2023,
 	title = {Course Materials for an Introduction to Data-Driven Chemistry},
 	volume = {6},
 	issn = {2577-3569},
@@ -53,9 +52,82 @@
 	file = {Full Text PDF:/home/vbettachini/storage/Zotero/storage/HQZH5ADM/Cumby et al. - 2023 - Course Materials for an Introduction to Data-Drive.pdf:application/pdf},
 }
 
-@online{noauthor_lagranges_nodate,
+@online{noauthorLagranges,
 	title = {Lagrange’s Method in Physics/Mechanics - {SymPy} 1.13.2 documentation},
 	url = {https://docs.sympy.org/latest/modules/physics/mechanics/lagrange.html},
 	urldate = {2024-08-19},
 	file = {Lagrange’s Method in Physics/Mechanics - SymPy 1.13.2 documentation:/home/vbettachini/storage/Zotero/storage/TCFNB4YU/lagrange.html:text/html},
+}
+
+@article{         harrisArrayNumpy:2020,
+ title         = {Array programming with {NumPy}},
+ author        = {Charles R. Harris and K. Jarrod Millman and St{\'{e}}fan J.
+                 van der Walt and Ralf Gommers and Pauli Virtanen and David
+                 Cournapeau and Eric Wieser and Julian Taylor and Sebastian
+                 Berg and Nathaniel J. Smith and Robert Kern and Matti Picus
+                 and Stephan Hoyer and Marten H. van Kerkwijk and Matthew
+                 Brett and Allan Haldane and Jaime Fern{\'{a}}ndez del
+                 R{\'{i}}o and Mark Wiebe and Pearu Peterson and Pierre
+                 G{\'{e}}rard-Marchant and Kevin Sheppard and Tyler Reddy and
+                 Warren Weckesser and Hameer Abbasi and Christoph Gohlke and
+                 Travis E. Oliphant},
+ year          = {2020},
+ month         = sep,
+ journal       = {Nature},
+ volume        = {585},
+ number        = {7825},
+ pages         = {357--362},
+ doi           = {10.1038/s41586-020-2649-2},
+ publisher     = {Springer Science and Business Media {LLC}},
+ url           = {https://doi.org/10.1038/s41586-020-2649-2}
+}
+
+@article{sciPyNMeth:2020,
+  author  = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and
+            Haberland, Matt and Reddy, Tyler and Cournapeau, David and
+            Burovski, Evgeni and Peterson, Pearu and Weckesser, Warren and
+            Bright, Jonathan and {van der Walt}, St{\'e}fan J. and
+            Brett, Matthew and Wilson, Joshua and Millman, K. Jarrod and
+            Mayorov, Nikolay and Nelson, Andrew R. J. and Jones, Eric and
+            Kern, Robert and Larson, Eric and Carey, C J and
+            Polat, {\.I}lhan and Feng, Yu and Moore, Eric W. and
+            {VanderPlas}, Jake and Laxalde, Denis and Perktold, Josef and
+            Cimrman, Robert and Henriksen, Ian and Quintero, E. A. and
+            Harris, Charles R. and Archibald, Anne M. and
+            Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and
+            {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
+  title   = {{{SciPy} 1.0: Fundamental Algorithms for Scientific
+            Computing in Python}},
+  journal = {Nature Methods},
+  year    = {2020},
+  volume  = {17},
+  pages   = {261--272},
+  adsurl  = {https://rdcu.be/b08Wh},
+  doi     = {10.1038/s41592-019-0686-2},
+}
+
+@Article{HunterMatplotlib:2007,
+  Author    = {Hunter, J. D.},
+  Title     = {Matplotlib: A 2D graphics environment},
+  Journal   = {Computing in Science \& Engineering},
+  Volume    = {9},
+  Number    = {3},
+  Pages     = {90--95},
+  abstract  = {Matplotlib is a 2D graphics package used for Python for
+  application development, interactive scripting, and publication-quality
+  image generation across user interfaces and operating systems.},
+  publisher = {IEEE COMPUTER SOC},
+  doi       = {10.1109/MCSE.2007.55},
+  year      = 2007
+}
+
+@article{vallejoGoogle:2022,
+  title={Google colab and virtual simulations: practical e-learning tools to support the teaching of thermodynamics and to introduce coding to students},
+  author={Vallejo, William and D{\'\i}az-Uribe, Carlos and Fajardo, Catalina},
+  journal={ACS omega},
+  volume={7},
+  number={8},
+  pages={7421--7429},
+  year={2022},
+  publisher={ACS Publications}
 }


### PR DESCRIPTION
modifque la forma en que ponemos los key de las citas, para que sea como el ejemplo de JOSE. Incluyo citas a los paquetes de python y una a Vallejos, et al de 2022 donde hablan de uso de Colab para física. Subo en una carpeta los papers. Uno de ellos (IEEE) me lo "pasaron".